### PR TITLE
Added catch to movePosition to mimic behavior of recast.

### DIFF
--- a/detourcrowd/src/main/java/org/recast4j/detour/crowd/PathCorridor.java
+++ b/detourcrowd/src/main/java/org/recast4j/detour/crowd/PathCorridor.java
@@ -391,7 +391,11 @@ public class PathCorridor {
 		m_path = mergeCorridorStartMoved(m_path, masResult.getVisited());
 		// Adjust the position to stay on top of the navmesh.
 		vCopy(m_pos, masResult.getResultPos());
-		m_pos[1] = navquery.getPolyHeight(m_path.get(0), masResult.getResultPos());
+		try {                    
+			m_pos[1] = navquery.getPolyHeight(m_path.get(0), masResult.getResultPos());                
+		} catch (IllegalArgumentException ex) {                    
+			//Silently catch. See #DetourPathCorridor.cpp.                
+		}		
 	}
 
 	/**


### PR DESCRIPTION
Catches the exception in getPolyHeight() but ignores it like recast does. Otherwise shuts down the app unnecessarily.